### PR TITLE
fix: Update bct.scss to allow showing of use default toggle in M6

### DIFF
--- a/src/css/bct.scss
+++ b/src/css/bct.scss
@@ -355,7 +355,7 @@ body.sq .bct-metadata .bct-tab-pane {
 }
 
 /* Metadata settings and description */
-.bct-metadata .sq-metadata-settings-wrapper {
+.bct-metadata .sq-metadata-settings-wrapper:not(:has(span.sq-metadata-default-wrapper)) {
   display: none;
 }
 


### PR DESCRIPTION
Add a check for preventing the display of the .sq-metdata-setting-wrapper as this is now wrapped around the "use default" check box, which means that when a default metdata field is used a user cannot change the metadata field.

This fix, shows the checkbox again allowing a user to uncheck the box.